### PR TITLE
Use un altered spec for environment

### DIFF
--- a/roles/pacificadispatcher/defaults/main.yml
+++ b/roles/pacificadispatcher/defaults/main.yml
@@ -2,7 +2,6 @@
 # defaults file for pacificadispatcher
 size: 1
 debug: false
-env: []
 secret_name: notify-subscription-secret
 secret_url_key: url
 secret_auth_type_key: type
@@ -18,11 +17,10 @@ subscription:
   jsonpath: '$.data'
   target_url: http://dispatcher.example.com/receive
 
-__int_env: []
 __init_containers:
   - name: wait-for-services
     image: busybox:1.28
-    env: "{{ env+__int_env }}"
+    env: "{{ _pacifica_dispatcher_io_pacificadispatcher_spec.env | default([]) }}"
     command:
       - sh
       - -c

--- a/roles/pacificadispatcher/tasks/main.yml
+++ b/roles/pacificadispatcher/tasks/main.yml
@@ -28,7 +28,7 @@
             containers:
               - name: "dispatcher"
                 image: "{{ image }}"
-                env: "{{ env+__int_env }}"
+                env: "{{ _pacifica_dispatcher_io_pacificadispatcher_spec.env | default([]) }}"
                 command: "{{ command }}"
                 volumeMounts:
                   - name: shareddata


### PR DESCRIPTION
### Description

This uses the un-altered custom resource spec for environment list.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
